### PR TITLE
Update sklearn-lifelines to work with newer versions of sklearn (0.20.1) and lifelines (0.17.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ coxph_surv_ppl.fit(data_train, y=data_train)
 
 #use pipeline to predict expected lifetime
 exp_lifetime = coxph_surv_ppl.predict(data_test[0:1])
-print 'expected lifetime: ' + str(exp_lifetime) 
+print('expected lifetime: ' + str(exp_lifetime))
 
 #or you can extract the model from the pipeline to access more methods
 coxmodel = coxph_surv_ppl.named_steps['coxphfittermodel'].estimator

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ data = lifelines.datasets.load_dd()
 # create sklearn pipeline
 coxph_surv_ppl = make_pipeline(PatsyTransformer('un_continent_name + regime + start_year -1', \
                                               return_type='dataframe'),
-                              CoxPHFitterModel(duration_column='duration',event_col='observed'))
+                              CoxPHFitterModel(duration_column='duration',event_col='observed',penalizer=0.001))
 
 #split data to train and test
 data_train, data_test = train_test_split(data)
@@ -42,24 +42,29 @@ coxmodel.print_summary()
 ```
 
 ```
-> expected lifetime: 5.0757889745799805
-> n=1356, number of events=1093
-> 
->                                 coef  exp(coef)     se(coef)       z      p    lower 0.95   upper 0.95     
-> un_continent_name[Africa]   -54.2263     0.0000 2723460.7001 -0.0000 1.0000 -5337939.1118 5337830.6593     
-> un_continent_name[Americas] -54.0287     0.0000 2723460.7001 -0.0000 1.0000 -5337938.9142 5337830.8568     
-> un_continent_name[Asia]     -53.9316     0.0000 2723460.7001 -0.0000 1.0000 -5337938.8172 5337830.9539     
-> un_continent_name[Europe]   -53.7841     0.0000 2723460.7001 -0.0000 1.0000 -5337938.6696 5337831.1014     
-> un_continent_name[Oceania]  -53.9123     0.0000 2723460.7001 -0.0000 1.0000 -5337938.7978 5337830.9732     
-> regime[T.Military Dict]       0.2687     1.3083       0.1177  2.2836 0.0224        0.0381       0.4994    *
-> regime[T.Mixed Dem]           1.2298     3.4204       0.1260  9.7610 0.0000        0.9828       1.4767  ***
-> regime[T.Monarchy]           -1.0500     0.3499       0.2524 -4.1600 0.0000       -1.5448      -0.5553  ***
-> regime[T.Parliamentary Dem]   0.7967     2.2181       0.1064  7.4869 0.0000        0.5881       1.0052  ***
-> regime[T.Presidential Dem]    1.0356     2.8168       0.1218  8.5012 0.0000        0.7968       1.2744  ***
-> start_year                   -0.0020     0.9980       0.0018 -1.1170 0.2640       -0.0055       0.0015     
+> expected lifetime: 5.075786636895757
+> <lifelines.CoxPHFitter: fitted with 1356 observations, 263 censored>
+>       duration col = 'duration'
+>          event col = 'observed'
+> number of subjects = 1356
+>   number of events = 1093
+>     log-likelihood = -6801.67
+>   time fit was run = 2019-01-27 22:01:35 UTC
 > ---
-> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1 
-> 
-> Concordance = 0.648
-> Likelihood ratio test = 293.767 on 11 df, p=0.00000
+>                              coef  exp(coef)  se(coef)     z      p  log(p)  lower 0.95  upper 0.95     
+> un_continent_name[Africa]   -0.26       0.77     36.18 -0.01   0.99   -0.01      -71.17       70.65     
+> un_continent_name[Americas] -0.06       0.94     36.18 -0.00   1.00   -0.00      -70.97       70.84     
+> un_continent_name[Asia]      0.03       1.03     36.18  0.00   1.00   -0.00      -70.88       70.94     
+> un_continent_name[Europe]    0.18       1.20     36.18  0.00   1.00   -0.00      -70.73       71.09     
+> un_continent_name[Oceania]   0.05       1.05     36.18  0.00   1.00   -0.00      -70.86       70.96     
+> regime[T.Military Dict]      0.27       1.31      0.12  2.28   0.02   -3.80        0.04        0.50    .
+> regime[T.Mixed Dem]          1.23       3.42      0.13  9.76 <0.005  -50.15        0.98        1.48  ***
+> regime[T.Monarchy]          -1.05       0.35      0.25 -4.16 <0.005  -10.36       -1.54       -0.56  ***
+> regime[T.Parliamentary Dem]  0.80       2.22      0.11  7.49 <0.005  -30.28        0.59        1.01  ***
+> regime[T.Presidential Dem]   1.04       2.82      0.12  8.50 <0.005  -38.51        0.80        1.27  ***
+> start_year                  -0.00       1.00      0.00 -1.12   0.26   -1.33       -0.01        0.00     
+> ---
+> Signif. codes: 0 '***' 0.0001 '**' 0.001 '*' 0.01 '.' 0.05 ' ' 1
+> Concordance = 0.65
+> Likelihood ratio test = 293.77 on 11 df, log(p)=-128.36
 ```

--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ pip install git+https://github.com/sashaostr/sklearn-lifelines.git
 
 # Example
 ```python
-import lifelines
 import lifelines.datasets
-from sklearn_lifelines.estimators_wrappers import CoxPHFitterModel
-from sklearn.pipeline import make_pipeline
-from sklearn.model_selection import train_test_split
+import numpy
 from patsylearn import PatsyTransformer
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+from sklearn_lifelines.estimators_wrappers import CoxPHFitterModel
+
+# Set seed for reproducible results
+numpy.random.seed(42)
 
 data = lifelines.datasets.load_dd()
 
@@ -39,24 +42,24 @@ coxmodel.print_summary()
 ```
 
 ```
-> expected lifetime: 4.44003472211
->
-> n=1356, number of events=1094
->
->                                 coef  exp(coef)  se(coef)          z         p  lower 0.95  upper 0.95     
->un_continent_name[Africa]    6.664e+00  7.834e+02       nan        nan       nan         nan         nan     
->un_continent_name[Americas]  7.375e+00  1.596e+03       nan        nan       nan         nan         nan     
->un_continent_name[Asia]      7.171e+00  1.301e+03       nan        nan       nan         nan         nan     
->un_continent_name[Europe]    8.190e+00  3.605e+03       nan        nan       nan         nan         nan     
->un_continent_name[Oceania]   4.183e+00  6.554e+01       nan        nan       nan         nan         nan     
->regime[T.Military Dict]      8.758e-02  1.092e+00 3.972e-02  2.205e+00 2.747e-02   9.707e-03   1.655e-01    *
->regime[T.Mixed Dem]          4.137e-01  1.512e+00 4.480e-02  9.235e+00 2.588e-20   3.259e-01   5.015e-01  ***
->regime[T.Monarchy]          -1.924e-01  8.250e-01 4.860e-02 -3.959e+00 7.539e-05  -2.877e-01  -9.712e-02  ***
->regime[T.Parliamentary Dem]  3.740e-01  1.453e+00 4.931e-02  7.584e+00 3.356e-14   2.773e-01   4.706e-01  ***
->regime[T.Presidential Dem]   3.440e-01  1.411e+00 4.660e-02  7.383e+00 1.546e-13   2.527e-01   4.354e-01  ***
->start_year                  -4.382e-02  9.571e-01 3.351e-02 -1.308e+00 1.910e-01  -1.095e-01   2.188e-02     
->
->Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1 
->
->Concordance = 0.654
+> expected lifetime: 5.0757889745799805
+> n=1356, number of events=1093
+> 
+>                                 coef  exp(coef)     se(coef)       z      p    lower 0.95   upper 0.95     
+> un_continent_name[Africa]   -54.2263     0.0000 2723460.7001 -0.0000 1.0000 -5337939.1118 5337830.6593     
+> un_continent_name[Americas] -54.0287     0.0000 2723460.7001 -0.0000 1.0000 -5337938.9142 5337830.8568     
+> un_continent_name[Asia]     -53.9316     0.0000 2723460.7001 -0.0000 1.0000 -5337938.8172 5337830.9539     
+> un_continent_name[Europe]   -53.7841     0.0000 2723460.7001 -0.0000 1.0000 -5337938.6696 5337831.1014     
+> un_continent_name[Oceania]  -53.9123     0.0000 2723460.7001 -0.0000 1.0000 -5337938.7978 5337830.9732     
+> regime[T.Military Dict]       0.2687     1.3083       0.1177  2.2836 0.0224        0.0381       0.4994    *
+> regime[T.Mixed Dem]           1.2298     3.4204       0.1260  9.7610 0.0000        0.9828       1.4767  ***
+> regime[T.Monarchy]           -1.0500     0.3499       0.2524 -4.1600 0.0000       -1.5448      -0.5553  ***
+> regime[T.Parliamentary Dem]   0.7967     2.2181       0.1064  7.4869 0.0000        0.5881       1.0052  ***
+> regime[T.Presidential Dem]    1.0356     2.8168       0.1218  8.5012 0.0000        0.7968       1.2744  ***
+> start_year                   -0.0020     0.9980       0.0018 -1.1170 0.2640       -0.0055       0.0015     
+> ---
+> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1 
+> 
+> Concordance = 0.648
+> Likelihood ratio test = 293.767 on 11 df, p=0.00000
 ```

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ pip install git+https://github.com/sashaostr/sklearn-lifelines.git
 # Example
 ```python
 import lifelines
+import lifelines.datasets
 from sklearn_lifelines.estimators_wrappers import CoxPHFitterModel
 from sklearn.pipeline import make_pipeline
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 from patsylearn import PatsyTransformer
 
 data = lifelines.datasets.load_dd()

--- a/sklearn_lifelines/estimators_wrappers.py
+++ b/sklearn_lifelines/estimators_wrappers.py
@@ -4,10 +4,9 @@ from sklearn.base import BaseEstimator
 from sklearn.utils.metaestimators import if_delegate_has_method
 
 class CoxPHFitterModel(BaseEstimator):
-    def __init__(self, duration_column=None, event_col=None, initial_beta=None, include_likelihood=False, strata=None, alpha=0.95, tie_method='Efron', normalize=True, penalizer=0.0, **kwargs):
+    def __init__(self, duration_column=None, event_col=None, initial_beta=None, include_likelihood=False, strata=None, alpha=0.95, tie_method='Efron', penalizer=0.0, **kwargs):
         self.alpha = alpha
         self.tie_method = tie_method
-        self.normalize = normalize
         self.penalizer = penalizer
 
         self.duration_column = duration_column
@@ -36,7 +35,7 @@ class CoxPHFitterModel(BaseEstimator):
         return self.estimator.predict_expectation(X)[0].values[0]
 
     def get_params(self, deep=True):
-        return {"alpha": self.alpha, "tie_method": self.tie_method, "normalize": self.normalize, "penalizer": self.penalizer}
+        return {"alpha": self.alpha, "tie_method": self.tie_method, "penalizer": self.penalizer}
 
 
 class AalenAdditiveFitterModel(BaseEstimator):

--- a/sklearn_lifelines/estimators_wrappers.py
+++ b/sklearn_lifelines/estimators_wrappers.py
@@ -1,6 +1,6 @@
 from lifelines import AalenAdditiveFitter
 from lifelines import CoxPHFitter
-from sklearn.pipeline import BaseEstimator
+from sklearn.base import BaseEstimator
 from sklearn.utils.metaestimators import if_delegate_has_method
 
 class CoxPHFitterModel(BaseEstimator):

--- a/sklearn_lifelines/estimators_wrappers.py
+++ b/sklearn_lifelines/estimators_wrappers.py
@@ -21,8 +21,7 @@ class CoxPHFitterModel(BaseEstimator):
         if self.event_col is not None:
             X_[self.event_col] = y[self.event_col]
 
-        params = self.get_params()
-        est = CoxPHFitter(**params)
+        est = CoxPHFitter(alpha=self.alpha, tie_method=self.tie_method, penalizer=self.penalizer)
 
         est.fit(X_, duration_col=self.duration_column, event_col=self.event_col, initial_beta=self.initial_beta, strata=self.strata, **fit_params)
         self.estimator = est
@@ -30,9 +29,6 @@ class CoxPHFitterModel(BaseEstimator):
 
     def predict(self, X):
         return self.estimator.predict_expectation(X)[0].values[0]
-
-    def get_params(self, deep=True):
-        return {"alpha": self.alpha, "tie_method": self.tie_method, "penalizer": self.penalizer}
 
 
 class AalenAdditiveFitterModel(BaseEstimator):
@@ -54,16 +50,11 @@ class AalenAdditiveFitterModel(BaseEstimator):
         if self.event_col is not None:
             X_[self.event_col] = y[self.event_col]
 
-        params = self.get_params()
-        est = AalenAdditiveFitter(**params)
+        est = AalenAdditiveFitter(fit_intercept=self.fit_intercept, alpha=self.alpha, coef_penalizer=self.coef_penalizer,
+                smoothing_penalizer=self.smoothing_penalizer)
         est.fit(X_, duration_col=self.duration_column, event_col=self.event_col, timeline=self.timeline, id_col = self.id_col, **fit_params)
         self.estimator = est
         return self
 
     def predict(self, X):
         return self.estimator.predict_expectation(X)[0].values[0]
-
-    def get_params(self, deep=True):
-        return {"fit_intercept": self.fit_intercept, "alpha": self.alpha, "coef_penalizer": self.coef_penalizer, "smoothing_penalizer": self.smoothing_penalizer}
-
-

--- a/sklearn_lifelines/estimators_wrappers.py
+++ b/sklearn_lifelines/estimators_wrappers.py
@@ -1,7 +1,6 @@
 from lifelines import AalenAdditiveFitter
 from lifelines import CoxPHFitter
 from sklearn.base import BaseEstimator
-from sklearn.utils.metaestimators import if_delegate_has_method
 
 class CoxPHFitterModel(BaseEstimator):
     def __init__(self, duration_column=None, event_col=None, initial_beta=None, strata=None, alpha=0.95, tie_method='Efron', penalizer=0.0, **kwargs):
@@ -29,7 +28,6 @@ class CoxPHFitterModel(BaseEstimator):
         self.estimator = est
         return self
 
-    @if_delegate_has_method(delegate='estimator')
     def predict(self, X):
         return self.estimator.predict_expectation(X)[0].values[0]
 
@@ -62,7 +60,6 @@ class AalenAdditiveFitterModel(BaseEstimator):
         self.estimator = est
         return self
 
-    @if_delegate_has_method(delegate='estimator')
     def predict(self, X):
         return self.estimator.predict_expectation(X)[0].values[0]
 

--- a/sklearn_lifelines/estimators_wrappers.py
+++ b/sklearn_lifelines/estimators_wrappers.py
@@ -4,7 +4,7 @@ from sklearn.base import BaseEstimator
 from sklearn.utils.metaestimators import if_delegate_has_method
 
 class CoxPHFitterModel(BaseEstimator):
-    def __init__(self, duration_column=None, event_col=None, initial_beta=None, include_likelihood=False, strata=None, alpha=0.95, tie_method='Efron', penalizer=0.0, **kwargs):
+    def __init__(self, duration_column=None, event_col=None, initial_beta=None, strata=None, alpha=0.95, tie_method='Efron', penalizer=0.0, **kwargs):
         self.alpha = alpha
         self.tie_method = tie_method
         self.penalizer = penalizer
@@ -13,7 +13,6 @@ class CoxPHFitterModel(BaseEstimator):
         self.event_col = event_col
 
         self.initial_beta = initial_beta
-        self.include_likelihood = include_likelihood
         self.strata = strata
 
 
@@ -26,7 +25,7 @@ class CoxPHFitterModel(BaseEstimator):
         params = self.get_params()
         est = CoxPHFitter(**params)
 
-        est.fit(X_, duration_col=self.duration_column, event_col=self.event_col, initial_beta=self.initial_beta, include_likelihood=self.include_likelihood, strata=self.strata, **fit_params)
+        est.fit(X_, duration_col=self.duration_column, event_col=self.event_col, initial_beta=self.initial_beta, strata=self.strata, **fit_params)
         self.estimator = est
         return self
 

--- a/sklearn_lifelines/tests/test_patsy_model.py
+++ b/sklearn_lifelines/tests/test_patsy_model.py
@@ -1,11 +1,17 @@
 import lifelines
-from sklearn_lifelines.estimators_wrappers import CoxPHFitterModel
-from sklearn.pipeline import make_pipeline
-from sklearn.cross_validation import train_test_split
+import lifelines.datasets
+import numpy
 from patsylearn import PatsyTransformer
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+
+from sklearn_lifelines.estimators_wrappers import CoxPHFitterModel
 
 
 def test_coxph_model():
+
+    # Set seed for reproducible results
+    numpy.random.seed(42)
 
     data = lifelines.datasets.load_dd()
 

--- a/sklearn_lifelines/tests/test_patsy_model.py
+++ b/sklearn_lifelines/tests/test_patsy_model.py
@@ -17,7 +17,7 @@ def test_coxph_model():
 
     # create sklearn pipeline
     coxph_surv_ppl = make_pipeline(PatsyTransformer('un_continent_name + regime + start_year -1', return_type='dataframe'),
-                                  CoxPHFitterModel(duration_column='duration',event_col='observed'))
+                                  CoxPHFitterModel(duration_column='duration',event_col='observed',penalizer=0.001))
 
     #split data to train and test
     data_train, data_test = train_test_split(data)


### PR DESCRIPTION
Various updates to make sklearn-lifelines work with newer versions of sklearn, lifelines and with python3.

With these changes, the sklearn-lifelines example from README works with lifelines 0.14.6.

Note that the example fails with "numpy.linalg.linalg.LinAlgError: Matrix is singular." with lifelines 0.15.x because the PatsyTransformer returns all levels as separate factors for the categorical variables in the dataset, which triggers an error in the newer version of lifelines.

Also note that the code was only tested for python3 and CoxPHFitterModel, but changes were also applied to AalenAdditiveFitterModel.

FYI: @CamDavidsonPilon 